### PR TITLE
Allow any indentation when parsing the endpoint PHPDoc

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -226,7 +226,7 @@ class Router
 
         // Parameters
         $parameters = array();
-        $nMatches = preg_match_all('/@param (\S+) \$?(\S+) ?([\S ]+)?/', $doc, $results);
+        $nMatches = preg_match_all('/@param\s+(\S+)\s+\$?(\S+)\s+([\S ]+)?/', $doc, $results);
         for ($i = 0; $i < $nMatches; $i++) {
             $parameterName = $this->camelcaseToHyphenated($results[2][$i]);
             $parameter = new \stdClass();

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -163,7 +163,7 @@ class RouterTest extends TestCase
         // Endpoints
 
         $this->assertCount(
-            2,
+            3,
             $result->endpoints['get']
         );
 
@@ -348,6 +348,85 @@ class RouterTest extends TestCase
         $this->assertSame(
             false,
             $result->param4
+        );
+    }
+
+    public function testMethodDocumentationParsing()
+    {
+        $router = new Router();
+        $controller = new TestController;
+
+        $result = $router->getMethodDocumentation($controller, "getRandomIndentationEndpoint");
+
+        
+        $this->assertArrayHasKey(
+            'description',
+            $result
+        );
+
+        $this->assertArrayHasKey(
+            'parameters',
+            $result
+        );
+
+        $this->assertSame(
+                    'This is the endpoint where PHPDoc is indented randomly',
+                    $result["description"]
+                );
+
+        $parameters = $result["parameters"];
+
+        $this->assertArrayHasKey(
+            'first',
+            $parameters
+        );
+
+         $this->assertArrayHasKey(
+            'second',
+            $parameters
+        );
+
+        $first = $parameters["first"];
+        $second = $parameters["second"];
+
+        $this->assertObjectHasAttribute(
+            'type',
+            $first
+        );
+
+        $this->assertObjectHasAttribute(
+            'description',
+            $first
+        );
+
+        $this->assertObjectHasAttribute(
+            'type',
+            $second
+        );
+
+        $this->assertObjectHasAttribute(
+            'description',
+            $second
+        );
+
+        $this->assertSame(
+            'string',
+            $first->type
+        );
+
+        $this->assertSame(
+            'Some string',
+            $first->description
+        );
+
+        $this->assertSame(
+            'float',
+            $second->type
+        );
+
+        $this->assertSame(
+            'Parameter with different indentation',
+            $second->description
         );
     }
 }

--- a/tests/TestData/TestController.php
+++ b/tests/TestData/TestController.php
@@ -89,4 +89,17 @@ class TestController extends Controller
     {
         return 'You found me!';
     }
+
+    /**
+     * This is the endpoint where PHPDoc is indented randomly
+     * 
+     * @param string $first Some string
+     * @param    float     $second     Parameter with different indentation
+     *
+     * @return bool Always true
+     */
+    public function getRandomIndentationEndpoint($first, $second)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Currently it is possible to have only a single space when describing a @param in the endpoint PHPDoc comment. This pull request allows to have 1 or more spaces between @param, variable type and description